### PR TITLE
Add Support for enum parameter via custom YARD @values tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ Or install it yourself as:
 
 ```rb
 class TestClass
-  # Get the current weather in a given location.
+  # Get the current temperature for a specific location.
   #
   # @param location [String] The city and state, e.g., San Francisco, CA.
-  # @param unit [String] The unit of temperature, either 'celsius' or 'fahrenheit'.
-  def get_current_weather(location:, unit: 'celsius')
+  # @param unit [String] The temperature unit to use. Infer this from the user's location.
+  # @values unit ["Celsius", "Fahrenheit"]
+  def get_current_temperature(location:, unit:)
     # Function implementation goes here
   end
 end
@@ -38,8 +39,8 @@ ToolTailor.convert(TestClass.instance_method(:get_current_weather))
 TestClass.instance_method(:get_current_weather).to_json_schema # => {
 #   "type" => "function",
 #   "function" => {
-#     "name" => "get_current_weather",
-#     "description" => "Get the current weather in a given location.",
+#     "name" => "get_current_temperature",
+#     "description" => "Get the current temperature for a specific location.",
 #     "parameters" => {
 #       "type" => "object",
 #       "properties" => {
@@ -49,14 +50,11 @@ TestClass.instance_method(:get_current_weather).to_json_schema # => {
 #         },
 #         "unit" => {
 #           "type" => "string",
-#           "description" => "The unit of temperature, either 'celsius' or 'fahrenheit'."
-#         },
-#         "api_key" => {
-#           "type" => "number",
-#           "description" => "The API key for the weather service."
+#           "description" => "The temperature unit to use. Infer this from the user's location.",
+#           "enum" => ["Celsius", "Fahrenheit"]
 #         }
 #       },
-#       "required" => ["location", "unit", "api_key"]
+#       "required" => ["location", "unit"]
 #     }
 #   }
 
@@ -65,8 +63,8 @@ example_instance = TestClass.new
 example_instance.method(:get_current_weather).to_json_schema # => {
 #   "type" => "function",
 #   "function" => {
-#     "name" => "get_current_weather",
-#     "description" => "Get the current weather in a given location.",
+#     "name" => "get_current_temperature",
+#     "description" => "Get the current temperature for a specific location.",
 #     "parameters" => {
 #       "type" => "object",
 #       "properties" => {
@@ -76,17 +74,13 @@ example_instance.method(:get_current_weather).to_json_schema # => {
 #         },
 #         "unit" => {
 #           "type" => "string",
-#           "description" => "The unit of temperature, either 'celsius' or 'fahrenheit'."
-#         },
-#         "api_key" => {
-#           "type" => "number",
-#           "description" => "The API key for the weather service."
+#           "description" => "The temperature unit to use. Infer this from the user's location.",
+#           "enum" => ["Celsius", "Fahrenheit"]
 #         }
 #       },
-#       "required" => ["location", "unit", "api_key"]
+#       "required" => ["location", "unit"]
 #     }
 #   }
-# }
 ```
 
 And with [ruby-openai](https://github.com/alexrudall/ruby-openai):
@@ -103,12 +97,12 @@ response =
         },
       ],
       tools: [
-        TestClass.instance_method(:get_current_weather).to_json_schema
+        TestClass.instance_method(:get_current_temperature).to_json_schema
       ],
       tool_choice: {
         type: "function",
         function: {
-          name: "get_current_weather"
+          name: "get_current_temperature"
         }
       }
     },
@@ -125,8 +119,8 @@ if message["role"] == "assistant" && message["tool_calls"]
     )
 
   case function_name
-  when "get_current_weather"
-    TestClass.get_current_weather(**args)
+  when "get_current_temperature"
+    TestClass.get_current_temperature(**args)
   end
 end
 # => "The weather is nice 🌞"

--- a/lib/tool_tailor.rb
+++ b/lib/tool_tailor.rb
@@ -1,6 +1,7 @@
 require "tool_tailor/version"
 require "json"
 require "yard"
+require "yard_custom_tags"
 
 module ToolTailor
   class Error < StandardError; end
@@ -38,7 +39,8 @@ module ToolTailor
       {
         name: name.to_s,
         type: "string",
-        description: ""
+        description: "",
+        enum: nil
       }
     end
 
@@ -55,6 +57,12 @@ module ToolTailor
           param[:description] = tag.text
         end
       end
+
+      yard_object.tags("values").each do |tag|
+        param_name = tag.name.chomp(':')
+        param = parameters.find { |p| p[:name] == param_name }
+        param[:enum] = tag.text if param
+      end
     end
 
     {
@@ -69,8 +77,9 @@ module ToolTailor
               param[:name],
               {
                 type: param[:type],
-                description: param[:description]
-              }
+                description: param[:description],
+                enum: param[:enum]
+              }.compact
             ]
           end.to_h,
           required: function.parameters.select { |type, _| type == :keyreq }.map { |_, name| name.to_s }

--- a/lib/yard_custom_tags.rb
+++ b/lib/yard_custom_tags.rb
@@ -1,0 +1,46 @@
+require "yard"
+
+module YARD
+  module Tags
+    # Custom tag class for handling `@values` tags.
+    class ValuesTag < YARD::Tags::Tag
+      TAG_FORMAT = /^(\S+)\s+\[(.+)\]$/
+
+      def initialize(tag_name, text)
+        name, values = parse_text(text)
+        super(tag_name, values, nil, name)
+      end
+
+      private
+
+      # Parses the text to match the expected format and extract the name and values.
+      def parse_text(text)
+        match = text.match(TAG_FORMAT)
+        unless match
+          raise ArgumentError, "Invalid @values tag format. Expected: @values <name> [value1, value2, ...]. Values should be a JSON array."
+        end
+
+        name, values_text = match.captures
+        values = parse_values(values_text)
+        [name, values]
+      end
+
+      # Parses the values text as a JSON array to ensure correct types.
+      def parse_values(values_text)
+        json_text = "[#{values_text}]"
+        JSON.parse(json_text)
+      rescue JSON::ParserError => e
+        raise ArgumentError, "Invalid values format: #{e.message}"
+      end
+    end
+
+    class Library
+      def self.define_custom_tag
+        # Defines a new custom tag `@values` using the ValuesTag class.
+        YARD::Tags::Library.define_tag("Values", :values, ValuesTag)
+      end
+    end
+  end
+end
+
+YARD::Tags::Library.define_custom_tag

--- a/spec/tool_tailor_spec.rb
+++ b/spec/tool_tailor_spec.rb
@@ -1,10 +1,10 @@
 class TestClass
-  # Get the current weather in a given location.
+  # Get the current temperature for a specific location.
   #
   # @param location [String] The city and state, e.g., San Francisco, CA.
-  # @param unit [String] The unit of temperature, either 'celsius' or 'fahrenheit'.
-  # @param api_key: [Float] The API key for the weather service.
-  def get_current_weather(location:, unit: 'celsius', api_key: nil)
+  # @param unit [String] The temperature unit to use. Infer this from the user's location.
+  # @values unit ["Celsius", "Fahrenheit"]
+  def get_current_temperature(location:, unit:)
     # Function implementation goes here
   end
 
@@ -25,8 +25,8 @@ RSpec.describe ToolTailor do
     expected_schema = {
       "type" => "function",
       "function" => {
-        "name" => "get_current_weather",
-        "description" => "Get the current weather in a given location.",
+        "name" => "get_current_temperature",
+        "description" => "Get the current temperature for a specific location.",
         "parameters" => {
           "type" => "object",
           "properties" => {
@@ -36,21 +36,18 @@ RSpec.describe ToolTailor do
             },
             "unit" => {
               "type" => "string",
-              "description" => "The unit of temperature, either 'celsius' or 'fahrenheit'."
-            },
-            "api_key" => {
-              "type" => "number",
-              "description" => "The API key for the weather service."
+              "description" => "The temperature unit to use. Infer this from the user's location.",
+              "enum" => ["Celsius", "Fahrenheit"]
             }
           },
-          "required" => ["location"]
+          "required" => ["location", "unit"]
         }
       }
     }.to_json
 
     # Assert that the generated schema matches the expected schema
-    expect(TestClass.instance_method(:get_current_weather).to_json_schema).to eq(expected_schema)
-    expect(TestClass.new.method(:get_current_weather).to_json_schema).to eq(expected_schema)
+    expect(TestClass.instance_method(:get_current_temperature).to_json_schema).to eq(expected_schema)
+    expect(TestClass.new.method(:get_current_temperature).to_json_schema).to eq(expected_schema)
   end
 
   it "handles missing YARD documentation gracefully" do


### PR DESCRIPTION
### Issue #1

This pull request introduces support for `enum` parameters via a custom YARD `@values` tag.

**Changes**:

- [x] Implemented a custom YARD tag `@values` to define possible values for a parameter, supporting `enum` as specified in the [OpenAI documentation](https://platform.openai.com/docs/assistants/tools/function-calling/quickstart).
- [x] Updated documentation to demonstrate the usage of the new `@values` tag. Additionally, aligned examples across the codebase (including tests and README) to ensure consistency and clarity, matching those used in the [OpenAI documentation](https://platform.openai.com/docs/assistants/tools/function-calling/quickstart).

**Format**:
```ruby
@values parameter_name [value1, value2, value3]
```

The values should be provided in a JSON array format to ensure proper parsing and validation. This tag supports all JSON-compatible types, including strings, integers, and hashes.

**Example**:
```ruby
# Get the current temperature for a specific location.
#
# @param location [String] The city and state, e.g., San Francisco, CA.
# @param unit [String] The temperature unit to use. Infer this from the user's location.
# @values unit ["Celsius", "Fahrenheit"]
def get_current_temperature(location:, unit:)
  # Function implementation goes here
end
```
```ruby
{
  "type" => "function",
  "function" => {
    "name" => "get_current_temperature",
    "description" => "Get the current temperature for a specific location.",
    "parameters" => {
      "type" => "object",
      "properties" => {
        "location" => {
          "type" => "string",
          "description" => "The city and state, e.g., San Francisco, CA."
        },
        "unit" => {
          "type" => "string",
          "description" => "The temperature unit to use. Infer this from the user's location.",
          "enum" => ["Celsius", "Fahrenheit"]
        }
      },
      "required" => ["location", "unit"]
    }
  }
}
```